### PR TITLE
Client#wait_for with block matcher argument

### DIFF
--- a/lib/chrome_remote/client.rb
+++ b/lib/chrome_remote/client.rb
@@ -6,14 +6,14 @@ module ChromeRemote
 
     def initialize(ws_url)
       @ws = WebSocketClient.new(ws_url)
-      @handlers = Hash.new {|hash, key| hash[key] = [] }
+      @handlers = Hash.new { |hash, key| hash[key] = [] }
     end
-  
-    def send_cmd(command, params = {})  
+
+    def send_cmd(command, params = {})
       msg_id = generate_unique_id
-      
+
       ws.send_msg({method: command, params: params, id: msg_id}.to_json)
-      
+
       msg = read_until { |msg| msg["id"] == msg_id }
       msg["result"]
     end
@@ -30,13 +30,17 @@ module ChromeRemote
       read_until { false }
     end
 
-    def wait_for(event_name)
-      msg = read_until { |msg| msg["method"] == event_name }
+    def wait_for(event_name=nil)
+      if event_name
+        msg = read_until { |msg| msg["method"] == event_name }
+      elsif block_given?
+        msg = read_until { |msg| yield(msg["method"], msg["params"]) }
+      end
       msg["params"]
     end
-  
+
     private
-  
+
     def generate_unique_id
       @last_id ||= 0
       @last_id += 1

--- a/spec/integration/chrome_remote_spec.rb
+++ b/spec/integration/chrome_remote_spec.rb
@@ -201,5 +201,15 @@ RSpec.describe ChromeRemote do
       result = client.wait_for("Network.requestWillBeSent")
       expect(received_events).to eq(1)
     end
+
+    it "waits for events with custom matcher block" do
+      server.send_msg({ method: "Page.lifecycleEvent", params: { "name" => "load" }}.to_json)
+      server.send_msg({ method: "Page.lifecycleEvent", params: { "name" => "DOMContentLoaded" }}.to_json)
+      result = client.wait_for do |event_name, event_params|
+        event_name == "Page.lifecycleEvent" && event_params["name"] == "DOMContentLoaded"
+      end
+
+      expect(result).to eq({"name" => "DOMContentLoaded"})
+    end
   end
 end


### PR DESCRIPTION
This addresses a use case I came across - the caller may want the ability to write a custom matcher on event params or event name.

For example, I may want to write a custom matcher that waits for either "Page.lifecycleEvent {name: 'load'}" OR "Page.frameStoppedLoading". This new block syntax allows me to do that.

```ruby
client.wait_for do |event_name, event_params|
  (event_name == "Page.lifecycleEvent" && event_params["name"] == "load") || 
    (event_name == "Page.frameStoppedLoading")
end
```

This also introduces Hashie::Mash for dot access to result properties, for easier introspection into nested properties.