### PR TITLE
WEB socket options

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ ChromeRemote provides a simple API that lets you send commands, and handle event
 To start with, you need an instance of the `ChromeRemote` class.
 
 ```ruby
-chrome = ChromeRemote.client host: 'localhost', # optional, default: localhost
-                             port: 9222         # optional, default: 9222
+chrome = ChromeRemote.client host: 'localhost',     # optional, default: localhost
+                             port: 9222,            # optional, default: 9222
+                             web_socket_options: {} # optional, default: {}, more: https://github.com/faye/websocket-driver-ruby
 ```
 
 Now, to send commands, ChromeRemote provides the `ChromeRemote#send_cmd` method. For example, this is how you make Chrome navigate to a url by sending the [Page.navigate][7] command:

--- a/README.md
+++ b/README.md
@@ -194,5 +194,3 @@ This project is intended to be a safe, welcoming space for collaboration, and co
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-
-test

--- a/README.md
+++ b/README.md
@@ -194,3 +194,5 @@ This project is intended to be a safe, welcoming space for collaboration, and co
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+
+test

--- a/lib/chrome_remote.rb
+++ b/lib/chrome_remote.rb
@@ -7,13 +7,14 @@ module ChromeRemote
   class << self
     DEFAULT_OPTIONS = {
       host: "localhost",
-      port: 9222
+      port: 9222,
+      web_socket_options: {}
     }
 
     def client(options = {})
       options = DEFAULT_OPTIONS.merge(options)
 
-      Client.new(get_ws_url(options))
+      Client.new(get_ws_url(options), options[:web_socket_options])
     end
 
     private

--- a/lib/chrome_remote/client.rb
+++ b/lib/chrome_remote/client.rb
@@ -4,8 +4,8 @@ module ChromeRemote
   class Client
     attr_reader :ws, :handlers
 
-    def initialize(ws_url)
-      @ws = WebSocketClient.new(ws_url)
+    def initialize(ws_url, web_socket_options = {})
+      @ws = WebSocketClient.new(ws_url, web_socket_options)
       @handlers = Hash.new { |hash, key| hash[key] = [] }
     end
 

--- a/lib/chrome_remote/web_socket_client.rb
+++ b/lib/chrome_remote/web_socket_client.rb
@@ -7,7 +7,7 @@ module ChromeRemote
 
     def initialize(url)
       @socket = ChromeRemote::Socket.new(url)
-      @driver = ::WebSocket::Driver.client(socket)
+      @driver = ::WebSocket::Driver.client(socket, max_length: 100000000)
 
       @messages = []
       @status = :closed

--- a/lib/chrome_remote/web_socket_client.rb
+++ b/lib/chrome_remote/web_socket_client.rb
@@ -5,9 +5,9 @@ module ChromeRemote
   class WebSocketClient
     attr_reader :socket, :driver, :messages, :status
 
-    def initialize(url)
+    def initialize(url, web_socket_options = {})
       @socket = ChromeRemote::Socket.new(url)
-      @driver = ::WebSocket::Driver.client(socket, max_length: 100000000)
+      @driver = ::WebSocket::Driver.client(socket, web_socket_options)
 
       @messages = []
       @status = :closed


### PR DESCRIPTION
Useful for changing WEB socket parameters:
chrome = ChromeRemote.client(port: port, web_socket_options: { max_length: 200000000 } )