### PR TITLE
add communication logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,17 @@ chrome.listen_until { requests == 5 }
 [8]: https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-requestWillBeSent
 [9]: https://chromedevtools.github.io/devtools-protocol/tot/Page/#event-loadEventFired
 
+### Logger
+
+To log all incoming and outgoing messages you can pass [Logger](https://github.com/ruby/logger) compatible instance to client.
+
+```ruby
+client = ChromeRemote.client(logger: Logger.new($stdout))
+client.send_cmd('Page.enable')
+# I, [2019-03-06T22:32:28.433643 #5070]  INFO -- : SEND ► {"method":"Page.enable","params":{},"id":1}
+# I, [2019-03-06T22:32:28.440294 #5070]  INFO -- : ◀ RECV {"id":1,"result":{}}
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment or any of the scripts in the `/examples` directory (e.g. `bundle exec ruby examples/network_dump_and_screenshot.rb`).

--- a/lib/chrome_remote.rb
+++ b/lib/chrome_remote.rb
@@ -12,8 +12,9 @@ module ChromeRemote
 
     def client(options = {})
       options = DEFAULT_OPTIONS.merge(options)
+      logger = options.delete(:logger)
 
-      Client.new(get_ws_url(options))
+      Client.new(get_ws_url(options), logger)
     end
 
     private

--- a/spec/integration/chrome_remote_spec.rb
+++ b/spec/integration/chrome_remote_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ChromeRemote do
   describe "Initializing a client" do
     it "returns a new client" do
       client = double("client")
-      expect(ChromeRemote::Client).to receive(:new).with(WS_URL) { client }
+      expect(ChromeRemote::Client).to receive(:new).with(WS_URL, nil) { client }
       expect(ChromeRemote.client).to eq(client)
     end
 
@@ -37,7 +37,7 @@ RSpec.describe ChromeRemote do
         ].to_json
       )
 
-      expect(ChromeRemote::Client).to receive(:new).with("ws://two")
+      expect(ChromeRemote::Client).to receive(:new).with("ws://two", nil)
       ChromeRemote.client
     end
 
@@ -45,8 +45,32 @@ RSpec.describe ChromeRemote do
       stub_request(:get, "http://192.168.1.1:9292/json").to_return(
         body: [{ "type": "page", "webSocketDebuggerUrl": "ws://one" }].to_json
       )
-      expect(ChromeRemote::Client).to receive(:new).with("ws://one")
+      expect(ChromeRemote::Client).to receive(:new).with("ws://one", nil)
       ChromeRemote.client host: '192.168.1.1', port: 9292
+    end
+
+    it "accepts logger" do
+      logger = double("logger")
+      client = double("client")
+
+      expect(ChromeRemote::Client).to receive(:new).with(WS_URL, logger) { client }
+      expect(ChromeRemote.client(logger: logger)).to eq(client)
+    end
+  end
+
+  describe "Logging" do
+    let(:logger) { double("logger") }
+    let!(:client) { ChromeRemote.client(logger: logger) }
+
+    it "logs incoming and outcoming messages" do
+      server.expect_msg do |msg|
+        msg = JSON.parse(msg)
+        server.send_msg({ id: msg["id"], params: {} }.to_json)
+      end
+
+      expect(logger).to receive(:info).with('SEND ► {"method":"Page.enable","params":{},"id":1}')
+      expect(logger).to receive(:info).with('◀ RECV {"id":1,"params":{}}')
+      client.send_cmd('Page.enable')
     end
   end
 


### PR DESCRIPTION
Hello, I have found out really useful during using [pupeeteer](https://github.com/GoogleChrome/puppeteer) to log all communication between client and chrome.

this is example of pupeeteer logger:

```
  puppeteer:protocol SEND ► {"method":"Target.closeTarget","params":{"targetId":"407B43B815CD69738CBFE597D1A11A4F"},"id":20} +2ms                                                             
  puppeteer:protocol ◀ RECV {"method":"Security.securityStateChanged","params":{"securityState":"neutral","schemeIsCryptographic":false,"explanations":[],"insecureContentStatus":{"ranMixedCo
ntent":false,"displayedMixedContent":false,"containedMixedForm":false,"ranContentWithCertErrors":false,"displayedContentWithCertErrors":false,"ranInsecureContentStyle":"unknown","displayedIn
secureContentStyle":"unknown"},"summary":""}, "sessionId": "F1731FE6E4629BB89E855EAE7CA348FB"} +1ms                                                                                           
```

I have tried to make it similar in this PR.

Usage and output:

```
client = ChromeRemote.client(logger: Logger.new($stdout))
client.send_cmd('Page.enable')
I, [2019-03-06T22:32:28.433643 #5070]  INFO -- : SEND ► {"method":"Page.enable","params":{},"id":1}                                                                                          
I, [2019-03-06T22:32:28.440294 #5070]  INFO -- : ◀ RECV {"id":1,"result":{}}
```