### PR TITLE
Initialize last_id only once.

### DIFF
--- a/lib/chrome_remote/client.rb
+++ b/lib/chrome_remote/client.rb
@@ -7,6 +7,7 @@ module ChromeRemote
     def initialize(ws_url)
       @ws = WebSocketClient.new(ws_url)
       @handlers = Hash.new { |hash, key| hash[key] = [] }
+      @last_id = 0
     end
 
     def send_cmd(command, params = {})
@@ -42,7 +43,6 @@ module ChromeRemote
     private
 
     def generate_unique_id
-      @last_id ||= 0
       @last_id += 1
     end
 


### PR DESCRIPTION
Hello.

During browsing codebase I have found out there's probably no need to check if `@last_id` is initialized everytime new id is needed, but it can be set during class initialization.